### PR TITLE
Make Runtime take an Options struct

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -6,6 +6,7 @@ use std::fs::read_to_string;
 
 use anathema::runtime::Runtime;
 use anathema::vm::Templates;
+use anathema_runtime::RuntimeOptions;
 
 fn main() {
     // Step one: Load and compile templates
@@ -14,7 +15,7 @@ fn main() {
     let templates = templates.compile().unwrap();
 
     // Step two: Runtime
-    let runtime = Runtime::new(&templates).unwrap();
+    let runtime = Runtime::new(&templates, RuntimeOptions::default()).unwrap();
 
     // Step three: start the runtime
     runtime.run().unwrap();

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -8,6 +8,7 @@ use anathema::core::{Event, KeyCode, Nodes, View};
 use anathema::runtime::Runtime;
 use anathema::values::{List, State, StateValue};
 use anathema::vm::Templates;
+use anathema_runtime::RuntimeOptions;
 
 #[derive(Debug, State)]
 struct RootState {
@@ -54,8 +55,14 @@ fn main() {
     let templates = templates.compile().unwrap();
 
     // Step three: setup runtime
-    let mut runtime = Runtime::new(&templates).unwrap();
-    runtime.enable_tabindex = false;
+    let mut runtime = Runtime::new(
+        &templates,
+        RuntimeOptions {
+            enable_tabindex: false,
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
     // Disable the alt screen if the application panics
     // and you want to see the panic message.

--- a/examples/multiview.rs
+++ b/examples/multiview.rs
@@ -11,6 +11,7 @@ use anathema::core::View;
 use anathema::runtime::Runtime;
 use anathema::values::{List, State, StateValue};
 use anathema::vm::Templates;
+use anathema_runtime::RuntimeOptions;
 
 // -----------------------------------------------------------------------------
 //   - Root -
@@ -92,7 +93,7 @@ fn main() {
     // -----------------------------------------------------------------------------
     //   - Runtime -
     // -----------------------------------------------------------------------------
-    let runtime = Runtime::new(&templates).unwrap();
+    let runtime = Runtime::new(&templates, RuntimeOptions::default()).unwrap();
 
     // -----------------------------------------------------------------------------
     //   - Start -


### PR DESCRIPTION
instead of mutating values after the runtime has been created (note, kept the fields for backwards compatible but we could just store the RuntimeOptions in the struct and then provide accessors for it)